### PR TITLE
Changes identicons format to address differences

### DIFF
--- a/src/components/AccountCard.vue
+++ b/src/components/AccountCard.vue
@@ -479,7 +479,7 @@ export default defineComponent({
         <q-card-section class="resources-container">
             <div class="inline-section">
                 <div class="items-center justify-center row full-height q-gutter-sm">
-                    <svg v-if="profile?.avatar" class="avatar-image" v-html="profile.avatar" />
+                    <img v-if="profile?.avatar" class="avatar-image" :src="profile.avatar" >
                     <div class="justify-center column">
                         <div class="items-center row">
                             <div class="text-title">{{ account }}</div>

--- a/src/components/ProfileCard.vue
+++ b/src/components/ProfileCard.vue
@@ -22,7 +22,7 @@ export default defineComponent({
 
 <template>
 <div class="profileCard__container">
-    <svg class="profileCard__avatar" v-html="profile?.avatar" />
+    <img class="profileCard__avatar" :src="profile?.avatar">
 </div>
 </template>
 

--- a/src/components/transaction/AccountFormat.vue
+++ b/src/components/transaction/AccountFormat.vue
@@ -45,7 +45,7 @@ export default defineComponent({
     class="items-center justify-center inline q-ma-0 accountFormat__link row q-gutter-xs"
     :href=" '/' + type + '/' + accAccount"
 >
-    <svg v-if="type !== 'transaction' && profile?.avatar" class="accountFormat__avatar" v-html="profile?.avatar" />
+    <img v-if="type !== 'transaction' && profile?.avatar" class="accountFormat__avatar" :src="profile?.avatar">
     <span class="q-ma-0"> {{type === 'transaction' ? accAccount.slice(0, 8) : accAccount}} </span>
     <q-tooltip v-if="type !== 'transaction' && profile?.avatar" :target="true">
         <ProfileCard :profile="profile"/>
@@ -64,5 +64,4 @@ export default defineComponent({
         height: 24px
         width: 24px
         object-fit: cover
-        border-radius: 30%
 </style>

--- a/src/components/transaction/DataFormat.vue
+++ b/src/components/transaction/DataFormat.vue
@@ -29,7 +29,7 @@ export default defineComponent({
         const transferData = computed(() => actionData.value as TransferData);
         const clientHeight = computed(() => dataBox.value?.clientHeight ?? 0);
         let currentData = ref<string | unknown>(null);
-        const maxHeight = 90; // the maximum row height
+        const maxHeight = 104; // the maximum row height
         const switchHeight = 20;
         const maxHeightStyle = `calc(${maxHeight}px - ${switchHeight}px)`;
 

--- a/src/stores/profiles.ts
+++ b/src/stores/profiles.ts
@@ -14,59 +14,149 @@ export const useProfileStore = defineStore('profiles', {
     state: (): ProfilesStateInterface => ({
         profiles: new Map<string, Profile>(),
     }),
-    getters: {
-    },
+    getters: {},
     actions: {
         async setProfile(account: string) {
             try {
                 const abi = await api.getABI(account);
 
-                const avatar = () => createAvatar(funEmoji, {
-                    seed: account,
-                    rotate: 0,
-                    scale: 118,
-                    radius: 28,
-                    backgroundColor: ['F1A12A', '4369E8', 'E72AC7', 'E8DA16', '98D4EB', '79CD6C', 'EDB7C0', 'F0C146', 'D9644A', '32A985', 'A78DDD', '423FEC', 'AFE39C', '8448E5', 'C9388F', '42D3F3'],
-                    backgroundType: ['gradientLinear', 'solid'],
-                    backgroundRotation: [10, 350],
-                    translateY: -6,
-                    mouth: ['cute', 'drip', 'faceMask', 'kissHeart', 'lilSmile', 'plain', 'shout', 'shy', 'smileLol', 'smileTeeth', 'tongueOut', 'wideSmile', 'pissed'],
-                });
+                const avatar = () =>
+                    createAvatar(funEmoji, {
+                        seed: account,
+                        rotate: 0,
+                        scale: 118,
+                        radius: 28,
+                        clip: true,
+                        backgroundColor: [
+                            'F1A12A',
+                            '4369E8',
+                            'E72AC7',
+                            'E8DA16',
+                            '98D4EB',
+                            '79CD6C',
+                            'EDB7C0',
+                            'F0C146',
+                            'D9644A',
+                            '32A985',
+                            'A78DDD',
+                            '423FEC',
+                            'AFE39C',
+                            '8448E5',
+                            'C9388F',
+                            '42D3F3',
+                        ],
+                        backgroundType: ['gradientLinear', 'solid'],
+                        backgroundRotation: [10, 350],
+                        translateY: -6,
+                        mouth: [
+                            'cute',
+                            'drip',
+                            'faceMask',
+                            'kissHeart',
+                            'lilSmile',
+                            'plain',
+                            'shout',
+                            'shy',
+                            'smileLol',
+                            'smileTeeth',
+                            'tongueOut',
+                            'wideSmile',
+                            'pissed',
+                        ],
+                    });
 
-                const botAvatar = () => createAvatar(bottts, {
-                    seed: account,
-                    radius: 28,
-                    rotate: 0,
-                    scale: 108,
-                    backgroundColor: ['transparent'],
-                    translateX: -3,
-                    translateY: 3,
-                    clip: true,
-                    randomizeIds: false,
-                    baseColor: ['4369E8', 'E72AC7', 'E8DA16', '98D4EB', '79CD6C', 'EDB7C0', 'F0C146', 'D9644A', '32A985', 'A78DDD', '423FEC', 'AFE39C', '8448E5', 'C9388F', '42D3F3'],
-                    eyes: ['bulging', 'dizzy', 'eva', 'frame1', 'frame2', 'glow', 'happy', 'hearts', 'robocop', 'round', 'roundFrame01', 'roundFrame02', 'sensor', 'shade01'],
-                    face: ['round01', 'round02', 'square01', 'square02', 'square03', 'square04'],
-                    mouth: ['bite', 'diagram', 'grill01', 'grill02', 'grill03', 'smile01', 'smile02', 'square01', 'square02'],
-                    mouthProbability: 80,
-                    sides: ['antenna01', 'antenna02', 'cables01', 'cables02', 'round', 'square', 'squareAssymetric'],
-                    sidesProbability: 83,
-                    texture: ['grunge01', 'grunge02', 'circuits', 'dots', 'dirty02'],
-                    textureProbability: 36,
-                    top: ['antenna', 'antennaCrooked', 'bulb01', 'glowingBulb01', 'glowingBulb02', 'horns', 'lights', 'pyramid', 'radar'],
-                    topProbability: 69,
-                });
+                const botAvatar = () =>
+                    createAvatar(bottts, {
+                        seed: account,
+                        radius: 28,
+                        rotate: 0,
+                        scale: 108,
+                        backgroundColor: ['transparent'],
+                        translateX: -3,
+                        translateY: 3,
+                        clip: true,
+                        randomizeIds: false,
+                        baseColor: [
+                            '4369E8',
+                            'E72AC7',
+                            'E8DA16',
+                            '98D4EB',
+                            '79CD6C',
+                            'EDB7C0',
+                            'F0C146',
+                            'D9644A',
+                            '32A985',
+                            'A78DDD',
+                            '423FEC',
+                            'AFE39C',
+                            '8448E5',
+                            'C9388F',
+                            '42D3F3',
+                        ],
+                        eyes: [
+                            'bulging',
+                            'dizzy',
+                            'eva',
+                            'frame1',
+                            'frame2',
+                            'glow',
+                            'happy',
+                            'hearts',
+                            'robocop',
+                            'round',
+                            'roundFrame01',
+                            'roundFrame02',
+                            'sensor',
+                            'shade01',
+                        ],
+                        face: ['round01', 'round02', 'square01', 'square02', 'square03', 'square04'],
+                        mouth: [
+                            'bite',
+                            'diagram',
+                            'grill01',
+                            'grill02',
+                            'grill03',
+                            'smile01',
+                            'smile02',
+                            'square01',
+                            'square02',
+                        ],
+                        mouthProbability: 80,
+                        sides: [
+                            'antenna01',
+                            'antenna02',
+                            'cables01',
+                            'cables02',
+                            'round',
+                            'square',
+                            'squareAssymetric',
+                        ],
+                        sidesProbability: 83,
+                        texture: ['grunge01', 'grunge02', 'circuits', 'dots', 'dirty02'],
+                        textureProbability: 36,
+                        top: [
+                            'antenna',
+                            'antennaCrooked',
+                            'bulb01',
+                            'glowingBulb01',
+                            'glowingBulb02',
+                            'horns',
+                            'lights',
+                            'pyramid',
+                            'radar',
+                        ],
+                        topProbability: 69,
+                    });
 
                 const profile = {
                     account: account,
-                    avatar: abi?.abi ? botAvatar().toString() : avatar().toString(),
+                    avatar: abi?.abi ? botAvatar().toDataUriSync() : avatar().toDataUriSync(),
                 } as Profile;
 
                 this.profiles.set(account, profile);
-
-            } catch(e) {
+            } catch (e) {
                 console.error(e);
             }
         },
     },
 });
-


### PR DESCRIPTION
Fixes #31 

The issue was caused by a mask that was set within the svg by the identicon API. For unknown reasons, that mask would cut few pixels on the right side of the identicon in some pages, thus looking different. 

The solution applies was to instead of using the svg format, use the dataURI, which provides a synchronous call. 

Also increased the maxim height slightly so three rows with identicon looks good. 